### PR TITLE
Correct variable name in documentation sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ var fs   = require('fs'),
 fs.readFile('/path/to/source.pdf', function(err, data) {
   temp.open({suffix: '.pdf'}, function(err, info) {
     if (err) throw err;
-    fs.write(info.fd, contents);
+    fs.write(info.fd, data);
     fs.close(info.fd, function(err) {
       if (err) throw err;
       // Do something with the file


### PR DESCRIPTION
Am I right about this?  Seems that the 'data' argument should be passed on down.  Documentation is important and this stymied me a bit when I looked at it.  Thanks!
